### PR TITLE
Automatically build and release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,73 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  push:
+    tags:
+      - 'v*.*'
+  pull_request:
+    branches: [ "main" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    
+    outputs:
+      release_version: ${{ steps.release_version.outputs.raw }}
+      formatted_release_version: ${{ steps.release_version.outputs.formatted }}
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+      
+      - name: Set env
+        id: release_version
+        run: |         
+          RELEASE_VERSION=${GITHUB_REF#refs/*/}
+          FORMATTED_RELEASE_VERSION="${RELEASE_VERSION//./_}"
+          FORMATTED_RELEASE_VERSION="${FORMATTED_RELEASE_VERSION//v/v_}"
+          
+          echo "::set-output name=raw::${GITHUB_REF#refs/*/}"
+          echo "::set-output name=formatted::${FORMATTED_RELEASE_VERSION}"
+      
+      - name: "Collect artifacts"
+        run: |
+          mkdir VersionReleaseArtifacts
+          mv *.py VersionReleaseArtifacts
+          mv Clonk.png VersionReleaseArtifacts
+          mv *license.txt VersionReleaseArtifacts
+          mv LICENSE VersionReleaseArtifacts
+          mv RenderClonk.blend VersionReleaseArtifacts
+          mkdir output
+          mv VersionReleaseArtifacts output/RenderClonkAddon_${{ steps.release_version.outputs.formatted }}
+          tree output
+      
+      - name: "Publish main artifact"
+        uses: actions/upload-artifact@v3
+        with:
+          name: RenderClonkAddon_${{ steps.release_version.outputs.formatted }}
+          path: output
+          
+      - name: "Collect release assets"
+        run: |
+          cd output
+          zip -q -r ../RenderClonkAddon_${{ steps.release_version.outputs.formatted }}.zip *
+          
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            RenderClonkAddon_${{ steps.release_version.outputs.formatted }}.zip
+          name: "RenderClonkAddon ${{ steps.release_version.outputs.raw }}"
+          


### PR DESCRIPTION
With this workflow you just have to enter the changes in the release body and use a valid tag in the format `v[0-9]+\.[0-9]+`. The Addon will be packed and attached to your release. The release title is set to `RenderClonkAddon <version-tag>`.
See also: https://github.com/Somebodyisnobody/RenderClonkAddon/releases/tag/v2.3